### PR TITLE
Fix OAuth2 init failure

### DIFF
--- a/bdfrx/connector.py
+++ b/bdfrx/connector.py
@@ -148,7 +148,7 @@ class RedditConnector(metaclass=ABCMeta):
                 scopes = self.cfg_parser.get("DEFAULT", "scopes", fallback="identity, history, read, save")
                 scopes = OAuth2Authenticator.split_scopes(scopes)
                 oauth2_authenticator = OAuth2Authenticator(
-                    scopes=scopes,
+                    wanted_scopes=scopes,
                     client_id=client_id,
                     client_secret=client_secret,
                     user_agent=self.user_agent,


### PR DESCRIPTION
There was an issue with how the variables were named in the constructor. I fixed the bug and now it can work properly.